### PR TITLE
fix(dark): fix oceanic_next_highlight_current_line

### DIFF
--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -250,13 +250,12 @@ call <sid>hi('xmlTagName',                 s:base05, '',       '',          '')
 call <sid>hi('xmlEndTag',                  s:base0C, '',       '',          '')
 " }}}
 "
-if exists('g:oceanic_next_highlight_current_line')
+if get(g:, 'oceanic_next_highlight_current_line', 0) == 1
 set cursorline
 call <sid>hi('CursorLine',                 '',       s:none, '',          '')
 " call <sid>hi('CursorLineNR',               s:base00, s:base00, '',          '')
 call <sid>hi('CursorLineNr',               s:base10, s:base00, '',          '')
 endif
-let g:oceanic_next_highlight_current_line = get(g:, 'oceanic_next_highlight_current_line', 0)
 
 let g:terminal_color_0=s:base00[0]
 let g:terminal_color_1=s:base08[0]


### PR DESCRIPTION
Hope to fix #58.

This PR will make highlight of current line number work if set `g:oceanic_next_highlight_current_line = 1`  and disabled in other cases when load config first time or reload it.

But I still hope that you can keep the color of background when highlight current line. Thanks a lot!