### PR TITLE
added option for end-of-buffer

### DIFF
--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -25,6 +25,9 @@
    let s:bold = "bold"
   endif
 "}}}
+" {{{ EndOfBuffer
+  let g:oceanic_next_disable_end_of_buffer = get(g:, 'oceanic_next_disable_end_of_buffer', 0)
+"}}}
 " {{{ Colors
   let s:base00=['#1b2b34', '235']
   let s:base01=['#343d46', '237']
@@ -95,7 +98,9 @@ call <sid>hi('Conceal',                    s:base0D, s:base00, '',          '')
 call <sid>hi('Cursor',                     s:base00, s:base05, '',          '')
 call <sid>hi('NonText',                    s:base03, '',       '',          '')
 call <sid>hi('Normal',                     s:base05, s:base00, '',          '')
-call <sid>hi('EndOfBuffer',                s:base05, s:base00, '',          '')
+if g:oceanic_next_disable_end_of_buffer == 0
+  call <sid>hi('EndOfBuffer',                s:base05, s:base00, '',          '')
+endif
 call <sid>hi('LineNr',                     s:base03, s:base00, '',          '')
 call <sid>hi('SignColumn',                 s:base00, s:base00, '',          '')
 call <sid>hi('StatusLine',                 s:base01, s:base03, '',          '')

--- a/colors/OceanicNextLight.vim
+++ b/colors/OceanicNextLight.vim
@@ -25,6 +25,9 @@
    let s:bold = "bold"
   endif
 " }}}
+" {{{ EndOfBuffer
+  let g:oceanic_next_disable_end_of_buffer = get(g:, 'oceanic_next_disable_end_of_buffer', 0)
+"}}}
 " {{{ Colors
   let s:base00=['#d8dee9', '253']
   let s:base01=['#cdd3de', '252']
@@ -94,7 +97,9 @@ call <sid>hi('Conceal',                    s:base0D, s:base00, '',          '')
 call <sid>hi('Cursor',                     s:base00, s:base05, '',          '')
 call <sid>hi('NonText',                    s:base03, '',       '',          '')
 call <sid>hi('Normal',                     s:base05, s:base00, '',          '')
-call <sid>hi('EndOfBuffer',                s:base05, s:base00, '',          '')
+if g:oceanic_next_disable_end_of_buffer == 0
+  call <sid>hi('EndOfBuffer',                s:base05, s:base00, '',          '')
+endif
 call <sid>hi('LineNr',                     s:base03, s:base00, '',          '')
 call <sid>hi('SignColumn',                 s:base00, s:base00, '',          '')
 call <sid>hi('StatusLine',                 s:base01, s:base03, '',          '')


### PR DESCRIPTION
First, thank you so much for all the hard work you have put into this. 


With a recent update of oceanic next I ran into a problem with my setup. I configure my terminal with a level of transparency (the desktop background is some what visible). It has worked well with oceanic-next in the past. However when i upgraded the plugin last week the behavior of the plugin changed and it now painted an opaque background. I was able to find the `EndOfBuffer` commit and added an option to not paint the opaque color. I tried to follow the same style of code please let me know if this can be me merged.

## Default Behavior
![screenshot 1524256824](https://user-images.githubusercontent.com/7818365/39073175-df3bde0e-44ba-11e8-81d2-807e1ee14896.jpg)
## Behavior with option
`let g:oceanic_next_disable_end_of_buffer = 1`
![screenshot 1524256954](https://user-images.githubusercontent.com/7818365/39073174-df3007dc-44ba-11e8-8907-14316abe8b5f.jpg)


