### PR TITLE
[Lightline] Make font more readable on colored segments

### DIFF
--- a/autoload/lightline/colorscheme/oceanicnext.vim
+++ b/autoload/lightline/colorscheme/oceanicnext.vim
@@ -5,25 +5,25 @@
 
 let s:p = {"normal": {}, "inactive": {}, "insert": {}, "replace": {}, "visual": {}, "tabline": {} }
 
-let s:p.normal.left = [[["#ffffff", 15], ["#6699cc", 68]], [["#ffffff", 15], ["#65737e", 243]]]
+let s:p.normal.left = [[["#343d46", 237], ["#6699cc", 68]], [["#ffffff", 15], ["#65737e", 243]]]
 let s:p.normal.middle = [[["#ffffff", 15], ["#343d46", 237]]]
 let s:p.normal.right = [[["#ffffff", 15], ["#65737e", 243]], [["#ffffff", 15], ["#65737e", 243]]]
-let s:p.normal.error = [[["#ffffff", 15], ["#ec5f67", 203]]]
-let s:p.normal.warning = [[["#ffffff", 15], ["#fac863", 221]]]
+let s:p.normal.error = [[["#343d46", 237], ["#ec5f67", 203]]]
+let s:p.normal.warning = [[["#343d46", 237], ["#fac863", 221]]]
 
 let s:p.inactive.left = [[["#d8dee9", 253], ["#65737e", 243]], [["#d8dee9", 253], ["#343d46", 237]]]
 let s:p.inactive.middle = [[["#65737e", 243], ["#343d46", 237]]]
 let s:p.inactive.right = [[["#d8dee9", 253], ["#343d46", 237]], [["#d8dee9", 253], ["#65737e", 243]]]
 
-let s:p.insert.left = [[["#ffffff", 15], ["#99c794", 114]], [["#ffffff", 15], ["#65737e", 243]]]
+let s:p.insert.left = [[["#343d46", 237], ["#99c794", 114]], [["#ffffff", 15], ["#65737e", 243]]]
 let s:p.insert.middle = [[["#ffffff", 15], ["#343d46", 237]]]
 let s:p.insert.right = [[["#ffffff", 15], ["#65737e", 243]], [["#ffffff", 15], ["#99c794", 114]]]
 
-let s:p.replace.left = [[["#ffffff", 15], ["#ec5f67", 203]], [["#ffffff", 15], ["#65737e", 243]]]
+let s:p.replace.left = [[["#343d46", 237], ["#ec5f67", 203]], [["#ffffff", 15], ["#65737e", 243]]]
 let s:p.replace.middle = [[["#ffffff", 15], ["#343d46", 237]]]
 let s:p.replace.right = [[["#ffffff", 15], ["#65737e", 243]], [["#ffffff", 15], ["#ec5f67", 203]]]
 
-let s:p.visual.left = [[["#ffffff", 15], ["#f99157", 209]], [["#ffffff", 15], ["#65737e", 243]]]
+let s:p.visual.left = [[["#343d46", 237], ["#f99157", 209]], [["#ffffff", 15], ["#65737e", 243]]]
 let s:p.visual.middle = [[["#ffffff", 15], ["#343d46", 237]]]
 let s:p.visual.right = [[["#ffffff", 15], ["#65737e", 243]], [["#ffffff", 15], ["#f99157", 209]]]
 


### PR DESCRIPTION
Texts on colored segments are on the edge of readability. This PR changes the color of the texts on typed segments to color of a background. It is better to explain it with screenshots (on the right there is a `w0rp/ale` integration):

**Before:**
![screenshot from 2018-05-06 14-43-28](https://user-images.githubusercontent.com/3652932/39674135-a30cfeba-5147-11e8-8e27-2c199b4f0bfb.png)
![screenshot from 2018-05-06 14-43-33](https://user-images.githubusercontent.com/3652932/39674137-a3289cec-5147-11e8-8aad-39459c134af5.png)
![screenshot from 2018-05-06 14-43-37](https://user-images.githubusercontent.com/3652932/39674138-a3465476-5147-11e8-8b60-c80602628cc5.png)

**After:**
![screenshot from 2018-05-06 14-41-25](https://user-images.githubusercontent.com/3652932/39674132-a28ad7f0-5147-11e8-9598-2787607b29bf.png)
![screenshot from 2018-05-06 14-42-05](https://user-images.githubusercontent.com/3652932/39674133-a2cc5d24-5147-11e8-8737-58e536471ea1.png)
![screenshot from 2018-05-06 14-42-23](https://user-images.githubusercontent.com/3652932/39674134-a2eafcde-5147-11e8-9056-01947c1ab381.png)