### PR TITLE
Add terminal cursor highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For vim, add the following to your `.vimrc`.
 colorscheme OceanicNext
  ```
 
-For neovim, add the following to your `.nvimrc`.
+For neovim, add the following to your `init.vim`.
 
 
 ```viml
@@ -74,6 +74,14 @@ If your terminal and setup supports it, you can enable italics and bold fonts wi
   colorscheme OceanicNext
 ```
 
+Optionally you can enable terminal cursor highlighting.
+This distinguishes between your terminal cursor and your Vim cursor while inside a terminal buffer in normal mode. Neovim only.
+
+To enable, add this before `colorscheme`:
+
+```viml
+  let g:oceanic_next_terminal_cursor_highlight = 1
+```
 
 
 ## Screenshot

--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -25,6 +25,9 @@
    let s:bold = "bold"
   endif
 "}}}
+" {{{ TermCursor
+  let g:oceanic_next_terminal_cursor_highlight = get(g:, 'oceanic_next_terminal_cursor_highlight', 0)
+" }}}
 " {{{ Colors
   let s:base00=['#1b2b34', '235']
   let s:base01=['#343d46', '237']
@@ -115,6 +118,9 @@ call <sid>hi('TabLineFill',                s:base03, s:base01, '',          '')
 call <sid>hi('TabLineSel',                 s:base0B, s:base01, '',          '')
 call <sid>hi('helpExample',                s:base0A, '',       '',          '')
 call <sid>hi('helpCommand',                s:base0A, '',       '',          '')
+if g:oceanic_next_terminal_cursor_highlight == 1 && has('nvim')
+  call <sid>hi('TermCursorNC',             s:base00, s:base09, '',          '')
+endif
 
 " Standard syntax highlighting
 call <sid>hi('Boolean',                    s:base09, '',       '',          '')


### PR DESCRIPTION
Inside a terminal buffer, highlight the terminal cursor in a different
color to distinguish between the terminal cursor position and the Vim
cursor position.

This option does not apply while in terminal mode, since the two cursors
are in the same position. The real benefit is to tell where your
terminal cursor is while *not* in terminal mode (aka, normal mode).

Since this is new and potentially confusing behavior, put it behind a
setting, and explain it in the README.

Example screenshot below. In normal mode, terminal cursor in orange, Vim cursor in white.
<img width="1280" alt="screen shot 2019-01-16 at 12 50 22 pm" src="https://user-images.githubusercontent.com/637174/51268149-5f367b80-198d-11e9-92fe-a8a6761a7d42.png">

Also fix outdated reference to `.nvimrc`.