### PR TITLE
Fix reversed colors for IncSearch

### DIFF
--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -74,7 +74,7 @@ call <sid>hi('ErrorMsg',                   s:base08, s:base00, '',          '')
 call <sid>hi('Exception',                  s:base08, '',       '',          '')
 call <sid>hi('FoldColumn',                 s:base0D, s:base00, '',          '')
 call <sid>hi('Folded',                     s:base03, s:base01, s:italic,    '')
-call <sid>hi('IncSearch',                  s:base01, s:base09, '',          '')
+call <sid>hi('IncSearch',                  s:base01, s:base09, 'NONE',      '')
 call <sid>hi('Italic',                     '',       '',       s:italic,    '')
 
 call <sid>hi('Macro',                      s:base08, '',       '',          '')

--- a/colors/OceanicNextLight.vim
+++ b/colors/OceanicNextLight.vim
@@ -73,7 +73,7 @@ call <sid>hi('ErrorMsg',                   s:base08, s:base00, '',          '')
 call <sid>hi('Exception',                  s:base08, '',       '',          '')
 call <sid>hi('FoldColumn',                 s:base0D, s:base00, '',          '')
 call <sid>hi('Folded',                     s:base03, s:base01, s:italic,    '')
-call <sid>hi('IncSearch',                  s:base01, s:base09, '',          '')
+call <sid>hi('IncSearch',                  s:base01, s:base09, 'NONE',      '')
 call <sid>hi('Italic',                     '',       '',       s:italic,    '')
 
 call <sid>hi('Macro',                      s:base08, '',       '',          '')


### PR DESCRIPTION
IncSearch's attribute will default to "reverse" unless we specify otherwise. This commit sets the attribute to 'NONE' so that it's easier to find the highlighted text.

This is what I see on `master`:
<img width="539" alt="bad" src="https://user-images.githubusercontent.com/4869194/53462176-c5380900-39f7-11e9-9edf-9bb677566b09.png">

And this is what I see on my branch:
<img width="535" alt="good" src="https://user-images.githubusercontent.com/4869194/53462165-bf422800-39f7-11e9-8bbb-d0835328fde7.png">

And here's what `:hi IncSearch` outputs for each, respectively:
```vim
IncSearch      xxx cterm=reverse ctermfg=237 ctermbg=209 gui=reverse guifg=#343d46 guibg=#f99157
```

```vim
IncSearch      xxx ctermfg=237 ctermbg=209 guifg=#343d46 guibg=#f99157
```