### PR TITLE
Fix bug with `fish` completions not highlighting selected option

### DIFF
--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -261,7 +261,7 @@ call <sid>hi('xmlEndTag',                  s:base0C, '',       '',          '')
 " }}}
 
 let g:terminal_color_0=s:base00[0]
-let g:terminal_color_8=s:base00[0]
+let g:terminal_color_8=s:base02[0]
 
 let g:terminal_color_1=s:base08[0]
 let g:terminal_color_9=s:base08[0]


### PR DESCRIPTION
Now the selected option will be highlighted / have a grey background.

This is what it looks like for me when searching completions in the `fish` shell in a terminal outside of `nvim` (I'm using iTerm2 with [the OceanicNext theme](https://github.com/mhartington/oceanic-next-iterm)):

<img width="829" alt="1-raw-terminal" src="https://user-images.githubusercontent.com/4869194/75097513-6486d200-5560-11ea-9490-b2c07790f82e.png">

Here's what the same thing looks like inside a terminal buffer in `nvim`:

<img width="829" alt="2-nvim-before-patch" src="https://user-images.githubusercontent.com/4869194/75097515-681a5900-5560-11ea-901a-ad9fc683e51b.png">

And here's what it looks like in a terminal buffer in `nvim` with this patch:

<img width="829" alt="3-nvim-after-patch" src="https://user-images.githubusercontent.com/4869194/75097516-68b2ef80-5560-11ea-8064-c83fbe18b300.png">

I think `base03` is closer to what the iTerm2 theme uses but `base02` is easier to read (for me, at least) and still clearly indicates which option is selected. Feel free to change it as you see fit.