### PR TITLE
fix: Revert `Normal` color to original base05 code

### DIFF
--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -94,7 +94,7 @@ endfunction
   call s:hi('Conceal',                    s:blue,   s:base00, '',          '')
   call s:hi('Cursor',                     s:base00, s:base05, '',          '')
   call s:hi('NonText',                    s:base03, '',       '',          '')
-  call s:hi('Normal',                     s:base07,  s:base00, '',          '')
+  call s:hi('Normal',                     s:base05,  s:base00, '',          '')
   call s:hi('EndOfBuffer',                s:base05, s:base00, '',          '')
   call s:hi('LineNr',                     s:base03, s:base00, '',          '')
   call s:hi('SignColumn',                 s:base00, s:base00, '',          '')


### PR DESCRIPTION
At https://github.com/mhartington/oceanic-next/commit/08158eec24cd154afd1623686aeb336fad580be7 (the latest branch with the original 'white' value) the color for `Normal` was `base05`. https://github.com/mhartington/oceanic-next/blob/08158eec24cd154afd1623686aeb336fad580be7/colors/OceanicNext.vim#L97

In https://github.com/mhartington/oceanic-next/commit/e58e5ee4ecbb5cf8f671f389db55d43dbb592f58 it was changed to `s:white`: https://github.com/mhartington/oceanic-next/blob/e58e5ee4ecbb5cf8f671f389db55d43dbb592f58/colors/OceanicNext.vim#L97

And in https://github.com/mhartington/oceanic-next/commit/29d694b9f6323c90fb0f3f54239090370caa99fb it wasn't reverted to `base05`, but `base07`, which is not full-white, but much brighter than the original `base05` color. https://github.com/mhartington/oceanic-next/blob/29d694b9f6323c90fb0f3f54239090370caa99fb/colors/OceanicNext.vim#L97