### PR TITLE
Add Colors for NeoVim LSP

### DIFF
--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -147,6 +147,23 @@ endfunction
   call s:hi('Type',                       s:yellow, '',       '',          '')
   call s:hi('Typedef',                    s:yellow, '',       '',          '')
 
+  " LSP
+  call s:hi('LspDiagnosticsDefaultError',         s:red,    '','','')
+  call s:hi('LspDiagnosticsSignError',            s:red,    '','','')
+  call s:hi('LspDiagnosticsUnderlineError',       s:red,    '','','')
+
+  call s:hi('LspDiagnosticsDefaultWarning',       s:yellow, '','','')
+  call s:hi('LspDiagnosticsSignWarning',          s:yellow, '','','')
+  call s:hi('LspDiagnosticsUnderlineWarning',     s:yellow, '','','')
+
+  call s:hi('LspDiagnosticsDefaultInformation',   s:blue,   '','','')
+  call s:hi('LspDiagnosticsSignInformation',      s:blue,   '','','')
+  call s:hi('LspDiagnosticsUnderlineInformation', s:blue,   '','','')
+
+  call s:hi('LspDiagnosticsDefaultHint',          s:cyan,   '','','')
+  call s:hi('LspDiagnosticsSignHint',             s:cyan,   '','','')
+  call s:hi('LspDiagnosticsUnderlineHint',        s:cyan,   '','','')
+
   " TreeSitter stuff
   call s:hi('TSInclude',                  s:cyan,   '',       '',          '')
   call s:hi('TSPunctBracket',             s:cyan,   '',       '',          '')


### PR DESCRIPTION
This adds color to the hints from NeoVim's LSP. 

I'm happy to fix the indentation of the other settings and add these to the light theme, but I wanted to get your sign off before I went ahead and made all those changes.

From:
![image](https://user-images.githubusercontent.com/1434705/103370894-e69a2e00-4a82-11eb-88ca-9dbcf23a5912.png)

To:
![image](https://user-images.githubusercontent.com/1434705/103370900-e8fc8800-4a82-11eb-92a0-2fe6a4ab6b1e.png)
