### PR TITLE
fixed viml function background

### DIFF
--- a/colors/OceanicNext.vim
+++ b/colors/OceanicNext.vim
@@ -65,6 +65,14 @@ function! s:hi(group, fg, bg, attr, attrsp)
     exec "hi " . a:group . " guisp=" . a:attrsp[0]
   endif
 endfunction
+
+
+" }}}
+" {{{ Make vim function highlighting behave like other functions
+hi! link vimFunc Function
+hi! link vimFunction Function
+hi! link vimUserFunc Function
+
 " }}}
 " {{{ call s::hi(group, fg, bg, gui, guisp)
   call s:hi('Bold',                               '',       '',       s:bold,      '')


### PR DESCRIPTION
I noticed that vim script function names have different backgrounds in certain situations. For example, if you turn on cursor line with `:set cursorline`, vim function names will have default dark background rather than cursorline background. I don't think this is the intended behavior. Correct me if I'm wrong.

This should be easy to reproduce. Please let me know if you can't.

Also, yesterday vim functions on my system had black background. Unfortunately, I wasn't able to reproduce it today.

This PR links the vim function highlight group to the normal function group. That way, by defining function group colors, vim functions "inherit" the same definitions. Does this sound reasonable?

This fix was inspired by looking at [nord's nord.vim](https://github.com/arcticicestudio/nord-vim/blob/master/colors/nord.vim). 