### PR TITLE
Add NormalFloat highlight group since Neovim 0.10 no longer links it to PMenu

### DIFF
--- a/autoload/oceanic_next.vim
+++ b/autoload/oceanic_next.vim
@@ -73,6 +73,7 @@ function! oceanic_next#highlight( base00, base01, base02, base03, base04, base05
   call s:hi('CursorLine',                        '',       a:base01, 'None',      '')
   call s:hi('CursorLineNR',                      a:base00, a:base00, '',          '')
   call s:hi('CursorLineNr',                      a:base03, a:base01, '',          '')
+  call s:hi('NormalFloat',                       a:base04, a:base01, '',          '')
   call s:hi('PMenu',                             a:base04, a:base01, '',          '')
   call s:hi('PMenuSel',                          a:base07, a:blue,   '',          '')
   call s:hi('PmenuSbar',                         '',       a:base02, '',          '')


### PR DESCRIPTION
As described here: https://neovim.io/doc/user/news.html

In Neovim 0.10 (or HEAD for now since it's not yet released), this causes black backgrounds for various popups instead of the gray background color the theme uses. Fixed by just manually assigning the same `PMenu` color to `NormalFloat` as well.

## Screenshots

On Neovim HEAD, before the PR is applied:

![CleanShot 2024-03-16 at 18 50 54](https://github.com/mhartington/oceanic-next/assets/1369558/d07a1926-0ca0-495b-8675-e7efa5ec5d67)


With the PR applied it looks like Neovim 0.9 again:

![CleanShot 2024-03-16 at 18 53 16](https://github.com/mhartington/oceanic-next/assets/1369558/0c374f3c-94e9-4154-a3c2-99254ebef014)


